### PR TITLE
v4l2 api and streaming api

### DIFF
--- a/docs/camera.yaml
+++ b/docs/camera.yaml
@@ -1,135 +1,204 @@
 paths:
-  /camera/configuration:
-    post:
-      tags:
-        - camera
-      summary: Set a new GStreamer pipeline to use for a specific camera
-      description: Set a new GStreamer pipeline to use. It should start with a 'h264parse'
-        element.
-      operationId: writePipeline
-      responses:
-        200:
-          description: successful operation
-          content:
-            application/json:
-              schema:
-                type: object
-                additionalProperties:
-                  schema:
-                    $ref: "#/components/schemas/cameraPipeline"
-              example:
-                /dev/video0: cameraPipeline
-        500:
-          description: Error writing pipeline
+  /camera/list/:
     get:
       tags:
         - camera
-      summary: Get all gstreamer pipelines
-      operationId: readPipelines
-      responses:
-        200:
-          description: successful operation
-          content:
-            application/json:
-              schema:
-                type: object
-                additionalProperties:
-                  schema:
-                    $ref: "#/components/schemas/cameraPipeline"
-              example:
-                /dev/video0: cameraPipeline
-        500:
-          description: Error writing pipeline
-
-  /camera/getV4L2cameras:
+      summary: list all video devices, including unsupported devices
+  /camera/list/supported:
     get:
       tags:
         - camera
-      summary: Get a List of available cameras via the V4L2 interface
-      description: Get the GStreamer pipeline currently in use
-      operationId: readV4L2Cameras
+      summary: list supported camera devices
+      description: list v4l2 devices that are cameras supporting video capture. This should be used to present camera selection UI to user in video configuration
       responses:
         200:
-          description: successful operation
+          description: success, a list of the supported cameras, and their attributes
           content:
             application/json:
-              schema:
-                type: string
-                example: TO-DO
-        500:
-          description: Error getting cameras list
-  /camera/profiles:
-    get:
-      tags:
-        - camera
-      summary: Get a List of available cameras via the V4L2 interface
-      description: Get the GStreamer pipeline currently in use
-      operationId: readV4L2profiles
-      responses:
-        200:
-          description: successful operation
-          content:
-            application/json:
-              schema:
-                type: string
-                example: TO-DO
-        500:
-          description: Error reading profiles
-  /camera/V4l2Control:
-    get:
-      tags:
-        - camera
-      summary: Get a List of available V4L2 Controls for the current camera
-      description: Get the GStreamer pipeline currently in use
-      operationId: readV4L2controls
-      responses:
-        200:
-          description: successful operation
-          content:
-            application/json:
-              schema:
-                type: string
-                example: TO-DO
-        500:
-          description: Error reading v4l2 controls
-    post:
-      tags:
-        - camera
-      summary: Get a List of available cameras via the V4L2 interface
-      description: Get the GStreamer pipeline currently in use
-      operationId: setV4L2Controls
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              required:
-                - id
-                - value
               properties:
-                id:
-                  type: integer
-                value:
-                  type: string
-        description: The network to connect to.
+                cameras:
+                  type: array
+                  items:
+                    type: object
+                    schema:
+                      $ref: "#/components/schemas/cameraInformation"
+  /camera/{id}/formats:
+    get:
+      tags:
+        - camera
+      summary: get a list of supported formats for a camera
+      responses:
+        200:
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/cameraFormats"
+        500:
+          description: error
+  /camera/{id}/format:
+    get:
+      tags:
+        - camera
+      summary: get the current camera format
+      produces:
+        - "application/vnd.cameraFormat+json"
+      responses:
+        200:
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/cameraFormat"
+      schemes: http
+    put:
+      tags:
+        - camera
+      summary: set the camera format
+      responses:
+        200:
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/cameraFormat"
+  /camera/{id}/controls:
+    get:
+      tags:
+        - camera
+      summary: get camera available controls, and their current values
+      responses:
+        200:
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/cameraControls"
+        500:
+          description: error
+  /camera/{id}/control/{control}:
+    get:
+      tags:
+        - camera
+      summary: get a camera control
+      produces:
+        - application/vnd.cameraControl+json
+      responses:
+        200:
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/cameraControl"
+    put:
+      tags:
+        - camera
+      summary: set a camera control
+      operationId: 
       responses:
         200:
           description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/cameraControl"
         500:
           description: Error setting control
+          content:
+            application/json:
+              properties:
+                error:
+                  type: string
+                  description: error message
+                  example: out of range, invalid control
 
 components:
   schemas:
-    cameraPipeline:
+    cameraInfomation:
       type: object
       properties:
-        rtsp-pipeline:
+        id:
+          type: integer
+        description:
           type: string
-          enum: [custom, rtsp]
-        pipeline:
+          example: HD Pro Webcam C920
+        bus:
           type: string
-          example: |
-            ! h264parse
-            ! queue
-            ! rtph264pay config-interval=10 pt=96
-            ! udpsink host=192.168.2.255 port=5600
+          example: usb-0000:34:00.3-3.1.4
+        path:
+          type: string
+          example: /dev/cam/0
+        capabilities:
+          type: integer
+          example: 4096
+    pixelFormat:
+      type: object
+      properties:
+        fourcc:
+          type: string
+          example: 'H264'
+    frameSize:
+      type: object
+      properties:
+        width:
+          type: integer
+          example: 1920
+        height:
+          type: integer
+          example: 1080
+    frameInterval:
+      type: object
+      properties:
+        numerator:
+          type: integer
+        denominator:
+          type: integer
+    cameraFormat:
+      title: "Mediatype identifier: application/vnd.cameraFormat+json; view=default"
+      description: a specific camera format specifying encoding (pixformat), frame size, and frame interval
+      type: object
+      properties:
+        pixelFormat:
+          type: object
+          schema:
+            $ref: "#/components/schemas/pixelFormat"
+        frameSize:
+          type: object
+          schema:
+            $ref: "#/components/schemas/frameSize"
+        frameInterval:
+          type: object
+          schema:
+            $ref: "#/components/schemas/frameInterval"
+    cameraFormats:
+      type: array
+      items:
+        type: object
+        schema:
+          $ref: "#/components/schemas/cameraFormat"
+    cameraControl:
+      title: "Mediatype identifier: application/vnd.cameraControl+json; view=default"
+      type: object
+      properties:
+        index:
+          type: integer
+        id:
+          type: integer
+        value:
+          type: integer
+        default:
+          type: integer
+        min:
+          type: integer
+        max:
+          type: integer
+        type:
+          type: integer
+        menu:
+          type: object
+    cameraControls:
+      type: array
+      items:
+        type: object
+        schema:
+          $ref: "#/components/schemas/cameraControl"

--- a/docs/camera.yaml
+++ b/docs/camera.yaml
@@ -79,7 +79,8 @@ paths:
     put:
       tags:
         - camera
-      summary: set the camera format
+      summary: Check the validity of the desired camera format
+      description: See VIDIOC_TRY_FMT https://www.kernel.org/doc/html/v4.9/media/uapi/v4l/vidioc-g-fmt.html. Check if the desired camera format is valid. This operation may be performed while the video device is accessed by the video streaming service. To apply the format, it should be POSTed to the video service
       responses:
         200:
           description: success

--- a/docs/camera.yaml
+++ b/docs/camera.yaml
@@ -21,6 +21,13 @@ paths:
       tags:
         - camera
       summary: get a list of supported formats for a camera
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          required: true
+          description: index of the video device path, eg 0 for /dev/video0
       responses:
         200:
           description: success
@@ -38,6 +45,19 @@ paths:
       tags:
         - camera
       summary: get a list of supported formats for a camera
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          required: true
+          description: index of the video device path, eg 0 for /dev/video0
+        - in: path
+          name: pixfmt
+          schema:
+            type: integer
+          required: true
+          description: The pixel format for which to query available frame sizes. This should match the `code` of one of the pixel formats returned by the /formats query
       responses:
         200:
           description: success
@@ -54,7 +74,32 @@ paths:
       description: See https://linuxtv.org/downloads/v4l-dvb-apis/userspace-api/v4l/vidioc-enum-frameintervals.html and struct v4l2_frmivalenum
       tags:
         - camera
-      summary: get a list of supported frameintervals for a given pixelFormat, width, and height
+      summary: get a list of supported frame intervals for a given pixelFormat, width, and height
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          required: true
+          description: index of the video device path, eg 0 for /dev/video0
+        - in: path
+          name: pixfmt
+          schema:
+            type: integer
+          required: true
+          description: The pixel format for which to query available frame intervals. This should match the `code` of one of the pixel formats returned by the /formats query
+        - in: path
+          name: width
+          schema:
+            type: integer
+          required: true
+          description: The frame width for which to query available frame intervals. This should match the `width` of one of the frame sizes returned by the /framesizes query
+        - in: path
+          name: height
+          schema:
+            type: integer
+          required: true
+          description: The frame height for which to query available frameintervals. This should match the `height` of one of the frame sizes returned by the /framesizes query
       responses:
         200:
           description: success
@@ -71,6 +116,13 @@ paths:
       tags:
         - camera
       summary: get the current camera format
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          required: true
+          description: index of the video device path, eg 0 for /dev/video0
       responses:
         200:
           description: success
@@ -84,6 +136,13 @@ paths:
         - camera
       summary: Check the validity of the desired camera format
       description: See VIDIOC_TRY_FMT https://www.kernel.org/doc/html/v4.9/media/uapi/v4l/vidioc-g-fmt.html. Check if the desired camera format is valid. This operation may be performed while the video device is accessed by the video streaming service. To apply the format, it should be POSTed to the video service
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          required: true
+          description: index of the video device path, eg 0 for /dev/video0
       responses:
         200:
           description: success
@@ -97,6 +156,13 @@ paths:
       tags:
         - camera
       summary: Get available controls for the video device
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          required: true
+          description: index of the video device path, eg 0 for /dev/video0
       responses:
         200:
           description: success
@@ -108,12 +174,19 @@ paths:
                   $ref: "#/components/schemas/controlInformation"
         500:
           description: error
-  /camera/{id}/control/{control}:
+  /camera/{id}/control/{controlId}:
     get:
       description: See VIDIOC_G_CTRL https://www.kernel.org/doc/html/v4.9/media/uapi/v4l/vidioc-g-ctrl.html
       tags:
         - camera
       summary: Get the current value for a video device control
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          required: true
+          description: index of the video device path, eg 0 for /dev/video0
       responses:
         200:
           description: success
@@ -121,11 +194,19 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/controlValue"
+  /camera/{id}/control/{controlId}/{value}:
     put:
       description: See VIDIOC_S_CTRL https://www.kernel.org/doc/html/v4.9/media/uapi/v4l/vidioc-g-ctrl.html
       tags:
         - camera
       summary: Set the value for a video device control
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          required: true
+          description: index of the video device path, eg 0 for /dev/video0
       responses:
         200:
           description: successful operation

--- a/docs/camera.yaml
+++ b/docs/camera.yaml
@@ -239,7 +239,6 @@ paths:
                   type: string
                   description: error message
                   example: out of range, invalid control
-
 components:
   schemas:
     capabilities:

--- a/docs/camera.yaml
+++ b/docs/camera.yaml
@@ -4,7 +4,7 @@ paths:
       tags:
         - camera
       summary: list video devices
-      description: list v4l2 devices.
+      description: List v4l2 devices and associated attributes. See https://linuxtv.org/downloads/v4l-dvb-apis/userspace-api/v4l/vidioc-querycap.html and struct v4l2_capability
       responses:
         200:
           description: success
@@ -17,6 +17,7 @@ paths:
                     $ref: "#/components/schemas/deviceInformation"
   /camera/{id}/formats:
     get:
+      description: See https://linuxtv.org/downloads/v4l-dvb-apis/userspace-api/v4l/vidioc-enum-fmt.html and struct v4l2_fmtdesc
       tags:
         - camera
       summary: get a list of supported formats for a camera
@@ -33,6 +34,7 @@ paths:
           description: error
   /camera/{id}/formats/{pixfmt}/framesizes:
     get:
+      description: See https://linuxtv.org/downloads/v4l-dvb-apis/userspace-api/v4l/vidioc-enum-framesizes.html and struct v4l2_frmsizeenum
       tags:
         - camera
       summary: get a list of supported formats for a camera
@@ -49,6 +51,7 @@ paths:
           description: error
   /camera/{id}/formats/{pixfmt}/{width}/{height}/frameintervals:
     get:
+      description: See https://linuxtv.org/downloads/v4l-dvb-apis/userspace-api/v4l/vidioc-enum-frameintervals.html and struct v4l2_frmivalenum
       tags:
         - camera
       summary: get a list of supported frameintervals for a given pixelFormat, width, and height

--- a/docs/camera.yaml
+++ b/docs/camera.yaml
@@ -163,9 +163,7 @@ components:
           type: string
           example: 'YUV 4:2:2'
         pixelFormat:
-          type: object
-          schema:
-            $ref: "#/components/schemas/pixelFormat"
+          $ref: "#/components/schemas/pixelFormat"
     frameSizeDiscrete:
       type: object
       properties:
@@ -204,9 +202,7 @@ components:
           type: integer
           example: 0
         pixelFormat:
-          type: object
-          schema:
-            $ref: "#/components/schemas/pixelFormat"
+          $ref: "#/components/schemas/pixelFormat"
         type:
           description: see enum v4l2_frmsizetypes
           type: integer
@@ -214,10 +210,8 @@ components:
         frameSize:
           type: object
           oneOf:
-            - schema:
-              $ref: "#/components/schemas/frameSizeDiscrete"
-            - schema:
-              $ref: "#/components/schemas/frameSizeStepwise"
+            - $ref: "#/components/schemas/frameSizeDiscrete"
+            - $ref: "#/components/schemas/frameSizeStepwise"
     frameIntervalDiscrete:
       type: object
       properties:
@@ -246,9 +240,7 @@ components:
           type: integer
           example: 0
         pixelFormat:
-          type: object
-          schema:
-            $ref: "#/components/schemas/pixelFormat"
+          $ref: "#/components/schemas/pixelFormat"
         width:
           type: integer
           example: 1920
@@ -262,23 +254,18 @@ components:
         frameInterval:
           type: object
           oneOf:
-            - schema:
-              $ref: "#/components/schemas/frameIntervalDiscrete"
-            - schema:
-              $ref: "#/components/schemas/frameIntervalStepwise"
+            - $ref: "#/components/schemas/frameIntervalDiscrete"
+            - $ref: "#/components/schemas/frameIntervalStepwise"
     cameraFormat:
       description: a specific camera format specifying encoding (pixformat), frame size, and frame interval
       type: object
       properties:
         pixelFormat:
-          schema:
-            $ref: "#/components/schemas/pixelFormat"
+          $ref: "#/components/schemas/pixelFormat"
         frameSize:
-          schema:
-            $ref: "#/components/schemas/frameSizeDiscrete"
+          $ref: "#/components/schemas/frameSizeDiscrete"
         frameInterval:
-          schema:
-            $ref: "#/components/schemas/frameIntervalDiscrete"
+          $ref: "#/components/schemas/frameIntervalDiscrete"
     cameraControl:
       type: object
       properties:
@@ -301,6 +288,4 @@ components:
     cameraControls:
       type: array
       items:
-        type: object
-        schema:
-          $ref: "#/components/schemas/cameraControl"
+        $ref: "#/components/schemas/cameraControl"

--- a/docs/camera.yaml
+++ b/docs/camera.yaml
@@ -105,7 +105,7 @@ paths:
               schema:
                 array:
                 items:
-                  $ref: "#/components/schemas/queryControl"
+                  $ref: "#/components/schemas/controlInformation"
         500:
           description: error
   /camera/{id}/control/{control}:
@@ -155,11 +155,7 @@ components:
           type: array
           items:
             - type: string
-          example:
-            - "Video Capture"
-            - "Metadata Capture"
-            - "Streaming"
-            - "Extended Pix Format"
+          example: [ "Video Capture", "Metadata Capture", "Streaming", "Extended Pix Format" ]
     deviceInformation:
       description: see https://linuxtv.org/downloads/v4l-dvb-apis/userspace-api/v4l/vidioc-querycap.html and struct v4l2_capability
       type: object
@@ -318,9 +314,11 @@ components:
       properties:
         id:
           type: integer
+          example: 0
         value:
           type: integer
-    queryMenu:
+          example: 1
+    controlMenu:
       description: See VIDIOC_QUERYMENU https://www.kernel.org/doc/html/v4.9/media/uapi/v4l/vidioc-queryctrl.html
       type: object
       properties:
@@ -333,7 +331,7 @@ components:
             type: string
           - value:
             type: integer
-    queryControl:
+    controlInformation:
       description: See VIDIOC_QUERYCTRL https://www.kernel.org/doc/html/v4.9/media/uapi/v4l/vidioc-queryctrl.html
       type: object
       properties:
@@ -357,4 +355,3 @@ components:
           items:
             $ref: "#/components/schemas/queryMenu"
       required: [ id, type, minimum, maximum, step, defaultValue, flags ]
-

--- a/docs/camera.yaml
+++ b/docs/camera.yaml
@@ -391,7 +391,6 @@ components:
           type: integer
           example: 0
         frameInterval:
-          type: object
           oneOf:
             - $ref: "#/components/schemas/frameIntervalDiscrete"
             - $ref: "#/components/schemas/frameIntervalStepwise"
@@ -423,15 +422,15 @@ components:
           type: integer
         index:
           type: integer
-        oneOf:
-          - type: object
-            properties:
-              name:
-                type: string
-          - type: object
-            properties:
-              value:
-                type: integer
+        name:
+          type: string
+        value:
+          type: integer
+      required: [id, index]
+          # this does not display correctly in the swagger ui, but is apparently the correct way
+      oneOf:
+        - required: [name]
+        - required: [value]
     controlInformation:
       description: See VIDIOC_QUERYCTRL https://www.kernel.org/doc/html/v4.9/media/uapi/v4l/vidioc-queryctrl.html
       type: object

--- a/docs/camera.yaml
+++ b/docs/camera.yaml
@@ -41,8 +41,6 @@ paths:
       tags:
         - camera
       summary: get the current camera format
-      produces:
-        - "application/vnd.cameraFormat+json"
       responses:
         200:
           description: success
@@ -114,30 +112,61 @@ paths:
 
 components:
   schemas:
-    cameraInfomation:
+    deviceInformation:
+      description: see https://linuxtv.org/downloads/v4l-dvb-apis/userspace-api/v4l/vidioc-querycap.html and struct v4l2_capability
       type: object
       properties:
-        id:
-          type: integer
+        driver:
+          type: string
+          example: uvcvideo
         description:
           type: string
           example: HD Pro Webcam C920
-        bus:
+        busInfo:
           type: string
           example: usb-0000:34:00.3-3.1.4
-        path:
+        version:
           type: string
-          example: /dev/cam/0
+          example: 5.7.9
         capabilities:
           type: integer
           example: 4096
+        deviceCapabilities:
+          type: integer
+          example: 4096
+        path:
+          type: string
+          example: /dev/video0
     pixelFormat:
       type: object
       properties:
+        format:
+          type: integer
+          example: 0
         fourcc:
           type: string
           example: 'H264'
-    frameSize:
+    formatDescription:
+      description: see https://linuxtv.org/downloads/v4l-dvb-apis/userspace-api/v4l/vidioc-enum-fmt.html and struct v4l2_fmtdesc
+      type: object
+      properties:
+        index:
+          type: integer
+          example: 0
+        type:
+          type: integer
+          example: 1
+        flags:
+          type: integer
+          example: 1
+        description:
+          type: string
+          example: 'YUV 4:2:2'
+        pixelFormat:
+          type: object
+          schema:
+            $ref: "#/components/schemas/pixelFormat"
+    frameSizeDiscrete:
       type: object
       properties:
         width:
@@ -146,38 +175,111 @@ components:
         height:
           type: integer
           example: 1080
-    frameInterval:
+    frameSizeStepwise:
       type: object
       properties:
-        numerator:
+        minWidth:
           type: integer
-        denominator:
+          example: 32
+        maxWidth:
           type: integer
-    cameraFormat:
-      title: "Mediatype identifier: application/vnd.cameraFormat+json; view=default"
-      description: a specific camera format specifying encoding (pixformat), frame size, and frame interval
+          example: 1920
+        stepWidth:
+          type: integer
+          example: 1
+        minHeight:
+          type: integer
+          example: 32
+        maxHeight:
+          type: integer
+          example: 1080
+        stepHeight:
+          type: integer
+          example: 1
+    frameSizeEnum:
+      description: see https://linuxtv.org/downloads/v4l-dvb-apis/userspace-api/v4l/vidioc-enum-framesizes.html and struct v4l2_frmsizeenum
       type: object
       properties:
+        index:
+          type: integer
+          example: 0
         pixelFormat:
           type: object
           schema:
             $ref: "#/components/schemas/pixelFormat"
+        type:
+          description: see enum v4l2_frmsizetypes
+          type: integer
+          example: 0
         frameSize:
           type: object
-          schema:
-            $ref: "#/components/schemas/frameSize"
-        frameInterval:
+          oneOf:
+            - schema:
+              $ref: "#/components/schemas/frameSizeDiscrete"
+            - schema:
+              $ref: "#/components/schemas/frameSizeStepwise"
+    frameIntervalDiscrete:
+      type: object
+      properties:
+        numerator:
+          type: integer
+          example: 1
+        denominator:
+          type: integer
+          example: 30
+    frameIntervalStepwise:
+      type: object
+      properties:
+        min:
+          type: integer
+          example: 1
+        max:
+          type: integer
+          example: 30
+        step:
+          type: integer
+          example: 1
+    frameIntervalEnum:
+      description: see https://linuxtv.org/downloads/v4l-dvb-apis/userspace-api/v4l/vidioc-enum-frameintervals.html and struct v4l2_frmivalenum
+      properties:
+        index:
+          type: integer
+          example: 0
+        pixelFormat:
           type: object
           schema:
-            $ref: "#/components/schemas/frameInterval"
-    cameraFormats:
-      type: array
-      items:
-        type: object
-        schema:
-          $ref: "#/components/schemas/cameraFormat"
+            $ref: "#/components/schemas/pixelFormat"
+        width:
+          type: integer
+          example: 1920
+        height:
+          type: integer
+          example: 1080
+        type:
+          description: see v4l2_frmivaltypes
+          type: integer
+          example: 0
+        frameInterval:
+          type: object
+          oneOf:
+            - schema:
+              $ref: "#/components/schemas/frameIntervalDiscrete"
+            - schema:
+              $ref: "#/components/schemas/frameIntervalStepwise"
+    cameraFormat:
+      description: a specific camera format specifying encoding (pixformat), frame size, and frame interval
+      type: object
+      properties:
+        pixelFormat:
+          schema:
+            $ref: "#/components/schemas/pixelFormat"
+        frameSize:
+          schema:
+            $ref: "#/components/schemas/frameSizeDiscrete"
+        frameInterval:
+          schema:
+            $ref: "#/components/schemas/frameIntervalDiscrete"
     cameraControl:
-      title: "Mediatype identifier: application/vnd.cameraControl+json; view=default"
       type: object
       properties:
         index:

--- a/docs/camera.yaml
+++ b/docs/camera.yaml
@@ -3,25 +3,18 @@ paths:
     get:
       tags:
         - camera
-      summary: list all video devices, including unsupported devices
-  /camera/list/supported:
-    get:
-      tags:
-        - camera
-      summary: list supported camera devices
-      description: list v4l2 devices that are cameras supporting video capture. This should be used to present camera selection UI to user in video configuration
+      summary: list video devices
+      description: list v4l2 devices.
       responses:
         200:
-          description: success, a list of the supported cameras, and their attributes
+          description: success
           content:
             application/json:
               properties:
                 cameras:
                   type: array
                   items:
-                    type: object
-                    schema:
-                      $ref: "#/components/schemas/cameraInformation"
+                    $ref: "#/components/schemas/deviceInformation"
   /camera/{id}/formats:
     get:
       tags:
@@ -33,7 +26,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/cameraFormats"
+                $ref: "#/components/schemas/formatList"
         500:
           description: error
   /camera/{id}/format:
@@ -164,6 +157,10 @@ components:
           example: 'YUV 4:2:2'
         pixelFormat:
           $ref: "#/components/schemas/pixelFormat"
+    formatList:
+      type: array
+      items:
+        $ref: "#/components/schemas/formatDescription"
     frameSizeDiscrete:
       type: object
       properties:
@@ -260,8 +257,8 @@ components:
       description: a specific camera format specifying encoding (pixformat), frame size, and frame interval
       type: object
       properties:
-        pixelFormat:
-          $ref: "#/components/schemas/pixelFormat"
+        format:
+          $ref: "#/components/schemas/formatDescription"
         frameSize:
           $ref: "#/components/schemas/frameSizeDiscrete"
         frameInterval:

--- a/docs/camera.yaml
+++ b/docs/camera.yaml
@@ -10,11 +10,10 @@ paths:
           description: success
           content:
             application/json:
-              properties:
-                cameras:
-                  type: array
-                  items:
-                    $ref: "#/components/schemas/deviceInformation"
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/deviceInformation"
   /camera/{id}/formats:
     get:
       description: See https://linuxtv.org/downloads/v4l-dvb-apis/userspace-api/v4l/vidioc-enum-fmt.html and struct v4l2_fmtdesc

--- a/docs/camera.yaml
+++ b/docs/camera.yaml
@@ -187,6 +187,12 @@ paths:
             type: integer
           required: true
           description: index of the video device path, eg 0 for /dev/video0
+        - in: path
+          name: controlId
+          schema:
+            type: integer
+          required: true
+          description: The id of the video device control. This should match the `id` property of a `controlInformation` object returned from the /controls query.
       responses:
         200:
           description: success
@@ -207,6 +213,18 @@ paths:
             type: integer
           required: true
           description: index of the video device path, eg 0 for /dev/video0
+        - in: path
+          name: controlId
+          schema:
+            type: integer
+          required: true
+          description: The id of the video device control. This should match the `id` property of a `controlInformation` object returned from the /controls query.
+        - in: path
+          name: value
+          schema:
+            type: integer
+          required: true
+          description: The value of the video device control. This should be in the allowed range specified by the `controlInformation` object returned from the /controls query.
       responses:
         200:
           description: successful operation

--- a/docs/camera.yaml
+++ b/docs/camera.yaml
@@ -26,7 +26,41 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/formatList"
+                array:
+                items:
+                  $ref: "#/components/schemas/formatDescription"
+        500:
+          description: error
+  /camera/{id}/formats/{pixfmt}/framesizes:
+    get:
+      tags:
+        - camera
+      summary: get a list of supported formats for a camera
+      responses:
+        200:
+          description: success
+          content:
+            application/json:
+              schema:
+                array:
+                items:
+                  $ref: "#/components/schemas/frameSizeEnum"
+        500:
+          description: error
+  /camera/{id}/formats/{pixfmt}/{width}/{height}/frameintervals:
+    get:
+      tags:
+        - camera
+      summary: get a list of supported frameintervals for a given pixelFormat, width, and height
+      responses:
+        200:
+          description: success
+          content:
+            application/json:
+              schema:
+                array:
+                items:
+                  $ref: "#/components/schemas/frameIntervalEnum"
         500:
           description: error
   /camera/{id}/format:
@@ -72,8 +106,6 @@ paths:
       tags:
         - camera
       summary: get a camera control
-      produces:
-        - application/vnd.cameraControl+json
       responses:
         200:
           description: success
@@ -105,6 +137,21 @@ paths:
 
 components:
   schemas:
+    capabilities:
+      type: object
+      properties:
+        code:
+          type: integer
+          example: 4096
+        caps:
+          type: array
+          items:
+            - type: string
+          example:
+            - "Video Capture"
+            - "Metadata Capture"
+            - "Streaming"
+            - "Extended Pix Format"
     deviceInformation:
       description: see https://linuxtv.org/downloads/v4l-dvb-apis/userspace-api/v4l/vidioc-querycap.html and struct v4l2_capability
       type: object
@@ -122,18 +169,16 @@ components:
           type: string
           example: 5.7.9
         capabilities:
-          type: integer
-          example: 4096
+          $ref: "#/components/schemas/capabilities"
         deviceCapabilities:
-          type: integer
-          example: 4096
+          $ref: "#/components/schemas/capabilities"
         path:
           type: string
           example: /dev/video0
     pixelFormat:
       type: object
       properties:
-        format:
+        code:
           type: integer
           example: 0
         fourcc:
@@ -157,10 +202,6 @@ components:
           example: 'YUV 4:2:2'
         pixelFormat:
           $ref: "#/components/schemas/pixelFormat"
-    formatList:
-      type: array
-      items:
-        $ref: "#/components/schemas/formatDescription"
     frameSizeDiscrete:
       type: object
       properties:

--- a/docs/camera.yaml
+++ b/docs/camera.yaml
@@ -129,7 +129,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/cameraFormat"
-      schemes: http
     put:
       tags:
         - camera
@@ -425,10 +424,14 @@ components:
         index:
           type: integer
         oneOf:
-          - name:
-            type: string
-          - value:
-            type: integer
+          - type: object
+            properties:
+              name:
+                type: string
+          - type: object
+            properties:
+              value:
+                type: integer
     controlInformation:
       description: See VIDIOC_QUERYCTRL https://www.kernel.org/doc/html/v4.9/media/uapi/v4l/vidioc-queryctrl.html
       type: object
@@ -451,5 +454,5 @@ components:
           description: This optional property is included for menu type controls to enumerate + describe the menu options
           type: array
           items:
-            $ref: "#/components/schemas/queryMenu"
+            $ref: "#/components/schemas/controlMenu"
       required: [ id, type, minimum, maximum, step, defaultValue, flags ]

--- a/docs/camera.yaml
+++ b/docs/camera.yaml
@@ -93,42 +93,46 @@ paths:
                 $ref: "#/components/schemas/cameraFormat"
   /camera/{id}/controls:
     get:
+      description: See VIDIOC_QUERYCTRL https://www.kernel.org/doc/html/v4.9/media/uapi/v4l/vidioc-queryctrl.html
       tags:
         - camera
-      summary: get camera available controls, and their current values
+      summary: Get available controls for the video device
       responses:
         200:
           description: success
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/cameraControls"
+                array:
+                items:
+                  $ref: "#/components/schemas/queryControl"
         500:
           description: error
   /camera/{id}/control/{control}:
     get:
+      description: See VIDIOC_G_CTRL https://www.kernel.org/doc/html/v4.9/media/uapi/v4l/vidioc-g-ctrl.html
       tags:
         - camera
-      summary: get a camera control
+      summary: Get the current value for a video device control
       responses:
         200:
           description: success
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/cameraControl"
+                $ref: "#/components/schemas/controlValue"
     put:
+      description: See VIDIOC_S_CTRL https://www.kernel.org/doc/html/v4.9/media/uapi/v4l/vidioc-g-ctrl.html
       tags:
         - camera
-      summary: set a camera control
-      operationId: 
+      summary: Set the value for a video device control
       responses:
         200:
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/cameraControl"
+                $ref: "#/components/schemas/controlValue"
         500:
           description: Error setting control
           content:
@@ -308,26 +312,49 @@ components:
           $ref: "#/components/schemas/frameSizeDiscrete"
         frameInterval:
           $ref: "#/components/schemas/frameIntervalDiscrete"
-    cameraControl:
+    controlValue:
+      description: See VIDIOC_G_CTRL, VIDIOC_S_CTRL, and struct v4l2_control https://www.kernel.org/doc/html/v4.9/media/uapi/v4l/vidioc-g-ctrl.html
       type: object
       properties:
-        index:
-          type: integer
         id:
           type: integer
         value:
           type: integer
-        default:
+    queryMenu:
+      description: See VIDIOC_QUERYMENU https://www.kernel.org/doc/html/v4.9/media/uapi/v4l/vidioc-queryctrl.html
+      type: object
+      properties:
+        id:
           type: integer
-        min:
+        index:
           type: integer
-        max:
+        oneOf:
+          - name:
+            type: string
+          - value:
+            type: integer
+    queryControl:
+      description: See VIDIOC_QUERYCTRL https://www.kernel.org/doc/html/v4.9/media/uapi/v4l/vidioc-queryctrl.html
+      type: object
+      properties:
+        id:
           type: integer
         type:
           type: integer
+        minimum:
+          type: integer
+        maximum:
+          type: integer
+        step:
+          type: integer
+        defaultValue:
+          type: integer
+        flags:
+          type: integer
         menu:
-          type: object
-    cameraControls:
-      type: array
-      items:
-        $ref: "#/components/schemas/cameraControl"
+          description: This optional property is included for menu type controls to enumerate + describe the menu options
+          type: array
+          items:
+            $ref: "#/components/schemas/queryMenu"
+      required: [ id, type, minimum, maximum, step, defaultValue, flags ]
+

--- a/docs/video.yaml
+++ b/docs/video.yaml
@@ -1,75 +1,95 @@
 paths:
   /stream/{cameraId}:
     get:
-      tags:
-        - stream
-      summary: get camera configuration
+      tags: [stream]
+      summary: Get video device stream configuration
       responses:
         200:
           description: success
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/cameraConfig"
+                $ref: "#/components/schemas/cameraConfiguration"
   /stream/{cameraId}/format:
     put:
-      summary: Set the video device output format
+      tags: [stream]
+      summary: Configure the video device output format
       parameters:
         - in: body
-        name: format
-        description: set the output format for a video device (eg h264, 1080p, 30fps)
-        schema:
-          $ref: "camera.yaml#/components/schema/cameraFormat"
+          name: format
+          description: set the output format for a video device (eg h264, 1080p, 30fps)
+          schema:
+            $ref: "camera.yaml#/components/schemas/cameraConfiguration"
+    responses:
+      200:
+        description: success
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/cameraConfiguration"
   /stream/{cameraId}/add:
     put:
+      tags: [stream]
       description: Add a stream configuration to the selected video device
       parameters:
         - in: path
-        name: cameraId
-        description: the video device to add a stream to
+          name: cameraId
+          description: the video device to add a stream to
         - in: body
-        name: stream
-        description: the stream configuration to add
-  /stream/{cameraId}/remove/{index}:
+          name: streamConfiguration
+          description: the stream configuration to add
+          schema:
+            $ref: "#/components/schemas/streamConfiguration"
+      responses:
+        200:
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/cameraConfiguration"
+  /stream/{cameraId}/remove:
     put:
+      tags: [stream]
       description: Remove a stream configuration from the selected video device
       parameters:
         - in: path
-        name: cameraId
-        description: the video device to remove a stream from
-        - in: path
-        name: index
-        description: the index of the stream configuration to remove
-
+          name: cameraId
+          description: the video device to remove a stream from
+        - in: query
+          name: index
+          description: the index of the stream configuration to remove
+      responses:
+        200:
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/cameraConfiguration"
 components:
   schemas:
-    streamConfig:
+    streamConfiguration:
       type: object
       properties:
-        index:
-          description: The index of this stream. A single video device may have multiple streams attributed to it.
-          type: integer
-          example: 0
         type:
           description: The video stream type
           type: string
           enum: [ "udp", "rtsp", "file" ]
           example: "udp"
         url:
-          description: Where the stream data is sent
+          description: Where the stream data is sent, this may be read only in the case of RTSP
           type: string
           example: "192.168.2.1:5600"
-    cameraConfig:
+    cameraConfiguration:
       type: object
       properties:
         device:
+          description: the video output format for the video device (eg h264, 1080p, 30fps)
           type: string
           example: "/dev/video0"
         format:
-          $ref: "camera.yaml#/components/schemas/cameraFormat"
+          schema:
+            $ref: 'camera.yaml#/components/schemas/cameraFormat'
         streams:
           type: array
           items:
-            ref$: "#/components/schemas/streamConfig"
+            - ref$: "#/components/schemas/streamConfiguration"

--- a/docs/video.yaml
+++ b/docs/video.yaml
@@ -1,0 +1,75 @@
+paths:
+  /stream/{cameraId}:
+    get:
+      tags:
+        - stream
+      summary: get camera configuration
+      responses:
+        200:
+          description: success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/cameraConfig"
+  /stream/{cameraId}/format:
+    put:
+      summary: Set the video device output format
+      parameters:
+        - in: body
+        name: format
+        description: set the output format for a video device (eg h264, 1080p, 30fps)
+        schema:
+          $ref: "camera.yaml#/components/schema/cameraFormat"
+  /stream/{cameraId}/add:
+    put:
+      description: Add a stream configuration to the selected video device
+      parameters:
+        - in: path
+        name: cameraId
+        description: the video device to add a stream to
+        - in: body
+        name: stream
+        description: the stream configuration to add
+  /stream/{cameraId}/remove/{index}:
+    put:
+      description: Remove a stream configuration from the selected video device
+      parameters:
+        - in: path
+        name: cameraId
+        description: the video device to remove a stream from
+        - in: path
+        name: index
+        description: the index of the stream configuration to remove
+
+components:
+  schemas:
+    streamConfig:
+      type: object
+      properties:
+        index:
+          description: The index of this stream. A single video device may have multiple streams attributed to it.
+          type: integer
+          example: 0
+        type:
+          description: The video stream type
+          type: string
+          enum: [ "udp", "rtsp", "file" ]
+          example: "udp"
+        url:
+          description: Where the stream data is sent
+          type: string
+          example: "192.168.2.1:5600"
+    cameraConfig:
+      type: object
+      properties:
+        device:
+          type: string
+          example: "/dev/video0"
+        format:
+          $ref: "camera.yaml#/components/schemas/cameraFormat"
+        streams:
+          type: array
+          items:
+            ref$: "#/components/schemas/streamConfig"

--- a/docs/video.yaml
+++ b/docs/video.yaml
@@ -20,13 +20,13 @@ paths:
           description: set the output format for a video device (eg h264, 1080p, 30fps)
           schema:
             $ref: "camera.yaml#/components/schemas/cameraConfiguration"
-    responses:
-      200:
-        description: success
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/cameraConfiguration"
+      responses:
+        200:
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/cameraConfiguration"
   /stream/{cameraId}/add:
     put:
       tags: [stream]
@@ -87,8 +87,7 @@ components:
           type: string
           example: "/dev/video0"
         format:
-          schema:
-            $ref: 'camera.yaml#/components/schemas/cameraFormat'
+          $ref: 'camera.yaml#/components/schemas/cameraFormat'
         streams:
           type: array
           items:

--- a/docs/video.yaml
+++ b/docs/video.yaml
@@ -5,11 +5,7 @@ paths:
       summary: Get video device stream configuration
       responses:
         200:
-          description: success
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/cameraConfiguration"
+          $ref: "#/components/responses/streamSuccess"
   /stream/{cameraId}/format:
     put:
       tags: [stream]
@@ -22,11 +18,7 @@ paths:
             $ref: "#/components/schemas/cameraFormat"
       responses:
         200:
-          description: success
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/cameraConfiguration"
+          $ref: "#/components/responses/streamSuccess"
   /stream/{cameraId}/add:
     put:
       tags: [stream]
@@ -42,11 +34,7 @@ paths:
             $ref: "#/components/schemas/streamConfiguration"
       responses:
         200:
-          description: success
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/cameraConfiguration"
+          $ref: "#/components/responses/streamSuccess"
   /stream/{cameraId}/remove:
     put:
       tags: [stream]
@@ -60,11 +48,7 @@ paths:
           description: the index of the stream configuration to remove
       responses:
         200:
-          description: success
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/cameraConfiguration"
+          $ref: "#/components/responses/streamSuccess"
 components:
   schemas:
     streamConfiguration:
@@ -92,3 +76,11 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/streamConfiguration"
+  responses:
+    streamSuccess:
+      description: success
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/cameraConfiguration"
+

--- a/docs/video.yaml
+++ b/docs/video.yaml
@@ -19,7 +19,7 @@ paths:
           name: format
           description: set the output format for a video device (eg h264, 1080p, 30fps)
           schema:
-            $ref: "camera.yaml#/components/schemas/cameraConfiguration"
+            $ref: "#/components/schemas/cameraFormat"
       responses:
         200:
           description: success
@@ -87,8 +87,8 @@ components:
           type: string
           example: "/dev/video0"
         format:
-          $ref: 'camera.yaml#/components/schemas/cameraFormat'
+          $ref: "#/components/schemas/cameraFormat"
         streams:
           type: array
           items:
-            - ref$: "#/components/schemas/streamConfiguration"
+            $ref: "#/components/schemas/streamConfiguration"


### PR DESCRIPTION
The goal here for the /camera api is to reflect the v4l2 api

supporting:
VIDIOC_QUERYCAP: https://www.kernel.org/doc/html/v4.9/media/uapi/v4l/vidioc-querycap.html
VIDIOC_ENUM_FMT: https://www.kernel.org/doc/html/v4.9/media/uapi/v4l/vidioc-enum-fmt.html
VIDIOC_ENUM_FRAMESIZES: https://www.kernel.org/doc/html/v4.9/media/uapi/v4l/vidioc-enum-framesizes.html
VIDIOC_ENUM_FRAMEINTERVALS: https://www.kernel.org/doc/html/v4.9/media/uapi/v4l/vidioc-enum-frameintervals.html
VIDIOC_G_FMT, VIDIOC_TRY_FMT, and VIDIOC_S_FMT: https://www.kernel.org/doc/html/v4.9/media/uapi/v4l/vidioc-g-fmt.html
  (set format will be a post to the video service, as discussed)

VIDIOC_QUERYCTL: https://www.kernel.org/doc/html/v4.9/media/uapi/v4l/vidioc-queryctrl.html
VIDIOC_G_CTRL AND VIDIOC_S_CTRL: https://www.kernel.org/doc/html/v4.9/media/uapi/v4l/vidioc-g-ctrl.html


The goal for the /stream api is to cover the functionality for configuring video streams.

I have not added error responses to all endpoints. I'd like to get approval on the endpoints and parameters (api functionality and coverage).